### PR TITLE
fix release tag .project

### DIFF
--- a/.project
+++ b/.project
@@ -2,7 +2,7 @@
 Title=xt7-player
 Startup=StartClass
 Icon=xt7-player-mpv.png
-Version=0.31.3144
+Version=0.33.3152
 Component=gb.args
 Component=gb.image
 Component=gb.qt5


### PR DESCRIPTION
This will show the actually release tag, under ?/info. 
Grazie babbo.